### PR TITLE
removing the SsiPciePkg included because the lcls-timing-core needs t…

### DIFF
--- a/LCLS-II/evr/rtl/EvrV2Core.vhd
+++ b/LCLS-II/evr/rtl/EvrV2Core.vhd
@@ -29,7 +29,7 @@ use ieee.NUMERIC_STD.all;
 use work.StdRtlPkg.all;
 use work.AxiLitePkg.all;
 use work.AxiStreamPkg.all;
-use work.SsiPciePkg.all;
+-- use work.SsiPciePkg.all;
 use work.TimingPkg.all;
 use work.EvrV2Pkg.all;
 --use work.PciPkg.all;

--- a/LCLS-II/evr/rtl/EvrV2PcieRxDesc.vhd
+++ b/LCLS-II/evr/rtl/EvrV2PcieRxDesc.vhd
@@ -27,7 +27,7 @@ use ieee.std_logic_arith.all;
 
 use work.StdRtlPkg.all;
 use work.AxiLitePkg.all;
-use work.SsiPciePkg.all;
+-- use work.SsiPciePkg.all;
 
 entity EvrV2PcieRxDesc is
    generic (

--- a/LCLS-II/evr/rtl/EvrV2PcieRxDma.vhd
+++ b/LCLS-II/evr/rtl/EvrV2PcieRxDma.vhd
@@ -32,7 +32,7 @@ use ieee.std_logic_unsigned.all;
 use work.StdRtlPkg.all;
 use work.AxiStreamPkg.all;
 use work.SsiPkg.all;
-use work.SsiPciePkg.all;
+-- use work.SsiPciePkg.all;
 
 entity EvrV2PcieRxDma is
    generic (


### PR DESCRIPTION
Commenting the reset of the SsiPciePkg included because the lcls-timing-core needs to be independent of this legacy SVN VHDL package