### PR TITLE
ESLCOMMON-233

### DIFF
--- a/python/LclsTimingCore/TimingFrameRx.py
+++ b/python/LclsTimingCore/TimingFrameRx.py
@@ -119,6 +119,7 @@ class TimingFrameRx(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "WO",
+            verify       = false,
         ))
 
         self.add(pr.RemoteVariable(    
@@ -129,6 +130,7 @@ class TimingFrameRx(pr.Device):
             bitOffset    =  0x01,
             base         = pr.UInt,
             mode         = "RO",
+            verify       = false,
         ))
 
         self.add(pr.RemoteVariable(    
@@ -139,6 +141,7 @@ class TimingFrameRx(pr.Device):
             bitOffset    =  0x02,
             base         = pr.UInt,
             mode         = "RW",
+            verify       = false,
         ))
 
         self.add(pr.RemoteVariable(    
@@ -149,6 +152,7 @@ class TimingFrameRx(pr.Device):
             bitOffset    =  0x03,
             base         = pr.UInt,
             mode         = "WO",
+            verify       = false,
         ))
 
         self.add(pr.RemoteVariable(    
@@ -159,6 +163,7 @@ class TimingFrameRx(pr.Device):
             bitOffset    =  0x04,
             base         = pr.UInt,
             mode         = "RW",
+            verify       = false,
         ))
 
         self.add(pr.RemoteVariable(    
@@ -169,6 +174,7 @@ class TimingFrameRx(pr.Device):
             bitOffset    =  0x05,
             base         = pr.UInt,
             mode         = "RW",
+            verify       = false,
         ))
 
         self.add(pr.RemoteVariable(    
@@ -179,6 +185,7 @@ class TimingFrameRx(pr.Device):
             bitOffset    =  0x06,
             base         = pr.UInt,
             mode         = "RW",
+            verify       = false,
         ))
 
         self.add(pr.RemoteVariable(
@@ -189,6 +196,7 @@ class TimingFrameRx(pr.Device):
             bitOffset    = 0x07,
             base         = pr.UInt,
             mode         = "WO",
+            verify       = false,
         ))
 
         self.add(pr.RemoteVariable(    


### PR DESCRIPTION
### Description
Due to offset 0x20 registers having a mix of R/W, RO and WO registers all on the same AXI-Lite 32-bit word, all remote variables on this 32-bit word alignment are now tagged as verify=false