### PR TITLE
Reset ignored by TimingSerializer, TimingDeserializer, TimingStreamTx

### DIFF
--- a/LCLS-II/core/rtl/TimingDeserializer.vhd
+++ b/LCLS-II/core/rtl/TimingDeserializer.vhd
@@ -183,7 +183,7 @@ begin
 
       -- On reset or error, reset the streams to invalidate accumulated data
       if (rst='1' or data.decErr/="00" or data.dspErr/="00") then
-        rin <= REG_INIT_C;
+        v := REG_INIT_C;
       end if;
 
       rin <= v;

--- a/LCLS-II/core/rtl/TimingSerializer.vhd
+++ b/LCLS-II/core/rtl/TimingSerializer.vhd
@@ -169,7 +169,7 @@ begin
       end case;
 
       if (rst='1') then
-        rin <= REG_INIT_C;
+        v := REG_INIT_C;
       end if;
       
       rin <= v;

--- a/LCLS-II/core/rtl/TimingStreamTx.vhd
+++ b/LCLS-II/core/rtl/TimingStreamTx.vhd
@@ -145,7 +145,7 @@ begin
       end case;
 
       if (rst='1') then
-        rin <= REG_INIT_C;
+        v := REG_INIT_C;
       end if;
       
       rin <= v;


### PR DESCRIPTION
The combinatorial code in these modules contained a bug which renders
the reset signal ineffective.

See [jira ticket](https://jira.slac.stanford.edu/browse/ESLTIMING-22)