### PR TITLE
remove use work.all;

### DIFF
--- a/LCLS-II/core/rtl/BsaControl.vhd
+++ b/LCLS-II/core/rtl/BsaControl.vhd
@@ -21,7 +21,6 @@
 -- 07/17/2015: created.
 -------------------------------------------------------------------------------
 library ieee;
-use work.all;
 
 library lcls_timing_core;
 use lcls_timing_core.TPGPkg.all;

--- a/LCLS-II/core/rtl/BsaControlv2.vhd
+++ b/LCLS-II/core/rtl/BsaControlv2.vhd
@@ -22,7 +22,6 @@
 -- 07/17/2015: created.
 -------------------------------------------------------------------------------
 library ieee;
-use work.all;
 
 library lcls_timing_core;
 use lcls_timing_core.TPGPkg.all;

--- a/LCLS-II/core/rtl/ClockTime.vhd
+++ b/LCLS-II/core/rtl/ClockTime.vhd
@@ -20,7 +20,6 @@
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 LIBRARY ieee;
-use work.all;
 
 USE ieee.std_logic_1164.ALL;
 use ieee.std_logic_arith.all;

--- a/LCLS-II/core/rtl/ClockTime_186MHz.vhd
+++ b/LCLS-II/core/rtl/ClockTime_186MHz.vhd
@@ -20,7 +20,6 @@
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 LIBRARY ieee;
-use work.all;
 
 USE ieee.std_logic_1164.ALL;
 use ieee.std_logic_arith.all;

--- a/LCLS-II/core/rtl/CtrControl.vhd
+++ b/LCLS-II/core/rtl/CtrControl.vhd
@@ -22,7 +22,6 @@
 -- 07/17/2015: created.
 -------------------------------------------------------------------------------
 library ieee;
-use work.all;
 
 library lcls_timing_core;
 use lcls_timing_core.TPGPkg.all;

--- a/LCLS-II/core/rtl/Divider.vhd
+++ b/LCLS-II/core/rtl/Divider.vhd
@@ -20,7 +20,6 @@
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 LIBRARY ieee;
-use work.all;
 
 library surf;
 use surf.StdRtlPkg.all;

--- a/LCLS-II/core/rtl/EventSelect.vhd
+++ b/LCLS-II/core/rtl/EventSelect.vhd
@@ -21,7 +21,6 @@
 -- 03/07/2016: created.
 -------------------------------------------------------------------------------
 library ieee;
-use work.all;
 
 library lcls_timing_core;
 use lcls_timing_core.TPGPkg.all;

--- a/LCLS-II/core/rtl/TPFifo.vhd
+++ b/LCLS-II/core/rtl/TPFifo.vhd
@@ -26,7 +26,6 @@
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 library ieee;
-use work.all;
 
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;

--- a/LCLS-II/core/rtl/TPGMini.vhd
+++ b/LCLS-II/core/rtl/TPGMini.vhd
@@ -20,7 +20,6 @@
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 library ieee;
-use work.all;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;

--- a/LCLS-II/core/rtl/TPGMiniStream.vhd
+++ b/LCLS-II/core/rtl/TPGMiniStream.vhd
@@ -22,7 +22,6 @@
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 library ieee;
-use work.all;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;

--- a/LCLS-II/core/rtl/TPGNotify.vhd
+++ b/LCLS-II/core/rtl/TPGNotify.vhd
@@ -20,7 +20,6 @@
 -- 09/15/2015: created.
 -------------------------------------------------------------------------------
 library ieee;
-use work.all;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;

--- a/LCLS-II/core/rtl/TPSerializer.vhd
+++ b/LCLS-II/core/rtl/TPSerializer.vhd
@@ -20,7 +20,6 @@
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 library ieee;
-use work.all;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;

--- a/LCLS-II/core/rtl/TimingDeserializer.vhd
+++ b/LCLS-II/core/rtl/TimingDeserializer.vhd
@@ -20,7 +20,6 @@
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 library ieee;
-use work.all;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;

--- a/LCLS-II/core/rtl/TimingSerialDelay.vhd
+++ b/LCLS-II/core/rtl/TimingSerialDelay.vhd
@@ -29,7 +29,6 @@
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 library ieee;
-use work.all;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;

--- a/LCLS-II/core/rtl/TimingSerializer.vhd
+++ b/LCLS-II/core/rtl/TimingSerializer.vhd
@@ -20,7 +20,6 @@
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 library ieee;
-use work.all;
 use ieee.std_logic_1164.all;
 
 library surf;

--- a/LCLS-II/core/rtl/TimingStreamTx.vhd
+++ b/LCLS-II/core/rtl/TimingStreamTx.vhd
@@ -20,7 +20,6 @@
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 library ieee;
-use work.all;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;

--- a/LCLS-II/core/rtl/WordSerializer.vhd
+++ b/LCLS-II/core/rtl/WordSerializer.vhd
@@ -20,7 +20,6 @@
 -- the terms contained in the LICENSE.txt file.
 -------------------------------------------------------------------------------
 library ieee;
-use work.all;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;

--- a/LCLS-II/evr/rtl/EvrV2EventSelect.vhd
+++ b/LCLS-II/evr/rtl/EvrV2EventSelect.vhd
@@ -25,8 +25,6 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
 
-use work.all;
-
 library lcls_timing_core;
 use lcls_timing_core.TPGPkg.all;
 

--- a/LCLS-II/evr/rtl/EvrV2FromV1.vhd
+++ b/LCLS-II/evr/rtl/EvrV2FromV1.vhd
@@ -26,8 +26,6 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
 
-use work.all;
-
 library surf;
 use surf.StdRtlPkg.all;
 

--- a/LCLS-II/evr/rtl/EvrV2Trigger.vhd
+++ b/LCLS-II/evr/rtl/EvrV2Trigger.vhd
@@ -29,8 +29,6 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_arith.all;
 use ieee.std_logic_unsigned.all;
 
-use work.all;
-
 library lcls_timing_core;
 use lcls_timing_core.TPGPkg.all;
 


### PR DESCRIPTION
### Description
- As part of the refactoring, removed all use of `use work.all;`