### PR TITLE
Update submodule locks

### DIFF
--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -8,8 +8,8 @@ if { [VersionCheck 2019.1 ] < 0 } {
 
 # Check for submodule tagging
 if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMODULE_LOCKS) == 0 } {
-   if { [SubmoduleCheck {ruckus} {2.0.4}  ] < 0 } {exit -1}
-   if { [SubmoduleCheck {surf}   {2.0.4}  ] < 0 } {exit -1}
+   if { [SubmoduleCheck {ruckus} {2.1.2}  ] < 0 } {exit -1}
+   if { [SubmoduleCheck {surf}   {2.0.6}  ] < 0 } {exit -1}
 } else {
    puts "\n\n*********************************************************"
    puts "OVERRIDE_SUBMODULE_LOCKS != 0"


### PR DESCRIPTION
Require surf v2.0.6 or later and ruckus v2.1.2 or later