### PR TITLE
v2.0.1 Release Candidate

### DIFF
--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -1,8 +1,8 @@
 # Load RUCKUS environment and library
 source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 
-# Check for Vivado version 2016.4 (or later)
-if { [VersionCheck 2016.4 ] < 0 } {
+# Check for Vivado version 2019.1 (or later)
+if { [VersionCheck 2019.1 ] < 0 } {
    exit -1
 }
 


### PR DESCRIPTION
 - Check for Vivado version 2019.1 (or later)
 - Update submodule locks #96 
