### PR TITLE
Tpg beamdiag

### DIFF
--- a/LCLS-II/core/rtl/TPGMiniStream.vhd
+++ b/LCLS-II/core/rtl/TPGMiniStream.vhd
@@ -29,7 +29,8 @@ use lcls_timing_core.TPGMiniEdefPkg.all;
 entity TPGMiniStream is
   generic (
     TPD_G     : time    := 1 ns;
-    AC_PERIOD : integer := 119000000/360;
+--    AC_PERIOD : integer := 119000000/360;
+    AC_PERIOD : integer := 200*1666;    -- a subharmonic of 71kHz
     NUM_EDEFS : natural := 4
     );
   port (

--- a/LCLS-II/core/rtl/TPGPkg.vhd
+++ b/LCLS-II/core/rtl/TPGPkg.vhd
@@ -138,13 +138,15 @@ package TPGPkg is
     buffered : sl;
     index    : slv(1 downto 0);        -- last buffer latched
     buffers  : Slv32Array(3 downto 0); -- tags and latch source
+    count    : slv(31 downto 0);
   end record;
 
   constant BEAM_DIAG_STATUS_INIT_C : BeamDiagStatusType := (
     latch    => '0',
     buffered => '0',
     index    => (others=>'0'),
-    buffers  => (others=>(others=>'0')) );
+    buffers  => (others=>(others=>'0')),
+    count    => (others=>'0') );
   
   type TPGStatusType is record
                           -- implemented resources
@@ -223,10 +225,12 @@ package TPGPkg is
   type BeamDiagControlType is record
     manfault   : sl;
     clear      : slv(30 downto 0);
+    holdoff    : slv(15 downto 0);
   end record;
   constant BEAM_DIAG_CONTROL_INIT_C : BeamDiagControlType := (
     manfault   => '0',
-    clear      => (others=>'0') );
+    clear      => (others=>'0'),
+    holdoff    => (others=>'0') );
   
   type TPGConfigType is record
                           clock_step      : slv( 4 downto 0);


### PR DESCRIPTION
Update LCLS1 timing emulation to generate beam on 71kHz boundaries like the real system.  Add holdoff and count registers to TPG fault control and status record types.