### PR TITLE
Software and simulation enhancements

### DIFF
--- a/LCLS-II/evr/rtl/EvrV2CoreTriggers.vhd
+++ b/LCLS-II/evr/rtl/EvrV2CoreTriggers.vhd
@@ -50,7 +50,7 @@ entity EvrV2CoreTriggers is
     evrRst              : in  sl;
     evrBus              : in  TimingBusType;
     -- Trigger and Sync Port
-    trigOut             : out TimingTrigType;
+    trigOut             : out TimingTrigType := TIMING_TRIG_INIT_C;
     evrModeSel          : in  sl := '1' );
 end EvrV2CoreTriggers;
 
@@ -77,13 +77,13 @@ architecture mapping of EvrV2CoreTriggers is
   
   signal channelConfig    : EvrV2ChannelConfigArray(NCHANNELS_G-1 downto 0);
   signal channelConfigS   : EvrV2ChannelConfigArray(NCHANNELS_G-1 downto 0);
-  signal channelConfigAV  : slv(NCHANNELS_G*EVRV2_CHANNEL_CONFIG_BITS_C-1 downto 0);
-  signal channelConfigSV  : slv(NCHANNELS_G*EVRV2_CHANNEL_CONFIG_BITS_C-1 downto 0);
+  signal channelConfigAV  : slv(NCHANNELS_G*EVRV2_CHANNEL_CONFIG_BITS_C-1 downto 0) := (others => '0');
+  signal channelConfigSV  : slv(NCHANNELS_G*EVRV2_CHANNEL_CONFIG_BITS_C-1 downto 0) := (others => '0');
 
   signal triggerConfig    : EvrV2TriggerConfigArray(NTRIGGERS_G-1 downto 0);
   signal triggerConfigS   : EvrV2TriggerConfigArray(NTRIGGERS_G-1 downto 0);
-  signal triggerConfigAV  : slv(NTRIGGERS_G*EVRV2_TRIGGER_CONFIG_BITS_C-1 downto 0);
-  signal triggerConfigSV  : slv(NTRIGGERS_G*EVRV2_TRIGGER_CONFIG_BITS_C-1 downto 0);
+  signal triggerConfigAV  : slv(NTRIGGERS_G*EVRV2_TRIGGER_CONFIG_BITS_C-1 downto 0) := (others => '0');
+  signal triggerConfigSV  : slv(NTRIGGERS_G*EVRV2_TRIGGER_CONFIG_BITS_C-1 downto 0) := (others => '0');
   
   signal timingMsg      : TimingMessageType := TIMING_MESSAGE_INIT_C;
   signal eventSel       : slv       (NTRIGGERS_G-1 downto 0) := (others=>'0');

--- a/LCLS-II/evr/rtl/EvrV2EventSelect.vhd
+++ b/LCLS-II/evr/rtl/EvrV2EventSelect.vhd
@@ -80,8 +80,10 @@ begin
    end process;
 
    destSel <= '1' when ((config.destSel(17 downto 16) = "10") or
-                        (config.destSel(17 downto 16) = "01" and not (dataIn.beamRequest(0)='1' and config.destSel(conv_integer(dataIn.beamRequest(7 downto 4))) = '1')) or
-                        (config.destSel(17 downto 16) = "00" and      dataIn.beamRequest(0)='1' and config.destSel(conv_integer(dataIn.beamRequest(7 downto 4))) = '1')) else
+                        (config.destSel(17 downto 16) = "01" and
+                         not (dataIn.beamRequest(0)='1' and config.destSel(conv_integer(dataIn.beamRequest(7 downto 4))) = '1')) or
+                        (config.destSel(17 downto 16) = "00" and
+                         dataIn.beamRequest(0)='1' and config.destSel(conv_integer(dataIn.beamRequest(7 downto 4))) = '1')) else
               '0';
 
 end EvrV2EventSelect;

--- a/LCLS-II/evr/rtl/EvrV2FromV1.vhd
+++ b/LCLS-II/evr/rtl/EvrV2FromV1.vhd
@@ -30,7 +30,7 @@ entity EvrV2FromV1 is
   port ( clk        : in  sl;
          disable    : in  sl;
          timingIn   : in  TimingBusType;
-         timingOut  : out TimingMessageType );
+         timingOut  : out TimingMessageType := TIMING_MESSAGE_INIT_C );
 end EvrV2FromV1;
 
 architecture EvrV2FromV1 of EvrV2FromV1 is

--- a/python/LclsTimingCore/EvrV2ChannelReg.py
+++ b/python/LclsTimingCore/EvrV2ChannelReg.py
@@ -65,7 +65,7 @@ class EvrV2ChannelReg(pr.Device):
                 1: 'AcRates',
                 2: 'ControlWord',
                 3: 'INVALID'}))
-        
+
         self.add(pr.RemoteVariable(
             name        = "RateSel",
             description = "Rate select",
@@ -86,7 +86,7 @@ class EvrV2ChannelReg(pr.Device):
                 0: 'BeamRequest',
                 1: 'NotBeamRequest',
                 3: 'Invalid'}))
-        
+
         self.add(pr.RemoteVariable(
             name        = "DestSel",
             description = "Destination select",

--- a/python/LclsTimingCore/EvrV2ChannelReg.py
+++ b/python/LclsTimingCore/EvrV2ChannelReg.py
@@ -55,19 +55,43 @@ class EvrV2ChannelReg(pr.Device):
             ))
         ########################################################
         self.add(pr.RemoteVariable(
+            name = 'RateType',
+            offset = 0x04,
+            bitSize = 2,
+            bitOffset = 11,
+            base = pr.UInt,
+            enum = {
+                0: 'FixedRates',
+                1: 'AcRates',
+                2: 'ControlWord',
+                3: 'INVALID'}))
+        
+        self.add(pr.RemoteVariable(
             name        = "RateSel",
             description = "Rate select",
             offset      = 0x04,
-            bitSize     = 13,
+            bitSize     = 11,
             bitOffset   = 0,
             mode        = "RW",
         ))
         #########################################################
         self.add(pr.RemoteVariable(
+            name = 'DestType',
+            offset = 0x04,
+            bitOffset = 29,
+            bitSize = 2,
+            base = pr.UInt,
+            enum = {
+                2: 'All',
+                0: 'BeamRequest',
+                1: 'NotBeamRequest',
+                3: 'Invalid'}))
+        
+        self.add(pr.RemoteVariable(
             name        = "DestSel",
             description = "Destination select",
             offset      = 0x04,
-            bitSize     = 19,
+            bitSize     = 16,
             bitOffset   = 13,
             mode        = "RW",
         ))


### PR DESCRIPTION
 - In `EvrV2ChannelReg.py`
    - Split RateType field from RateSel register variable
    - Split DestType field from DestSel register variable
    - **This might mess up some existing config files?**
 - Add default signal assignments so that registers have an initial value in simulation.