### PR TITLE
TimingFrameRx.py Bug Fix and TimingCore.vhd Update

### DIFF
--- a/LCLS-II/core/rtl/TimingCore.vhd
+++ b/LCLS-II/core/rtl/TimingCore.vhd
@@ -104,10 +104,10 @@ architecture rtl of TimingCore is
          addrBits                 => 16,
          connectivity             => ite(USE_TPGMINI_C, X"FFFF", x"0000")));
 
-   signal locAxilWriteMasters : AxiLiteWriteMasterArray(NUM_AXIL_MASTERS_C-1 downto 0);
-   signal locAxilWriteSlaves  : AxiLiteWriteSlaveArray (NUM_AXIL_MASTERS_C-1 downto 0);
-   signal locAxilReadMasters  : AxiLiteReadMasterArray (NUM_AXIL_MASTERS_C-1 downto 0);
-   signal locAxilReadSlaves   : AxiLiteReadSlaveArray (NUM_AXIL_MASTERS_C-1 downto 0);
+   signal locAxilWriteMasters : AxiLiteWriteMasterArray(NUM_AXIL_MASTERS_C-1 downto 0) := (others => AXI_LITE_WRITE_MASTER_INIT_C);
+   signal locAxilWriteSlaves  : AxiLiteWriteSlaveArray (NUM_AXIL_MASTERS_C-1 downto 0) := (others => AXI_LITE_WRITE_SLAVE_EMPTY_DECERR_C);
+   signal locAxilReadMasters  : AxiLiteReadMasterArray (NUM_AXIL_MASTERS_C-1 downto 0) := (others => AXI_LITE_READ_MASTER_INIT_C);
+   signal locAxilReadSlaves   : AxiLiteReadSlaveArray  (NUM_AXIL_MASTERS_C-1 downto 0) := (others => AXI_LITE_READ_SLAVE_EMPTY_DECERR_C);
 
    signal timingRx            : TimingRxType;
    signal timingStrobe        : sl;

--- a/python/LclsTimingCore/TimingFrameRx.py
+++ b/python/LclsTimingCore/TimingFrameRx.py
@@ -193,6 +193,7 @@ class TimingFrameRx(pr.Device):
             bitSize      = 1,
             bitOffset    = 0x09,
             mode         = "RW" if clkselMode == 'SELECT' else 'RO',
+            verify       = False, # No verification because axilR.modeSelEn=0x0 can overwrite ModeSel with ClkSel
             enum         = {
                 0x0: 'Lcls1Protocol',
                 0x1: 'Lcls2Protocol',


### PR DESCRIPTION
### Description
- setting ModeSel.verify = False
  - No verification because axilR.modeSelEn=0x0 can overwrite ModeSel with ClkSel
- TimingCore AXI-Lite bus init terminations