### PR TITLE
Remove prescaler reset from LCLS-I evr trigger logic

### DIFF
--- a/LCLS-I/evr/EvrV1EventReceiver.vhd
+++ b/LCLS-I/evr/EvrV1EventReceiver.vhd
@@ -367,7 +367,7 @@ begin
    end generate GEN_EVENT_RX_CH;
 
    preScaleRst <= '1' when(EventStreamDly = x"7B") else '0';
-   eventChRst  <= evrRst or not(evrEnable) or not(rxLinkUp) or preScaleRst;
+   eventChRst  <= evrRst or not(evrEnable) or not(rxLinkUp);
 
    ------------------------
    -- Decode the time stamp


### PR DESCRIPTION
This removes from the trigger logic a reset that occurs every 360 Hz fiducial.  In the MRF design, this reset was not intended for the trigger logic but for a prescaler on special frequency outputs.