### PR TITLE
v3.4.2 release candidate

### DIFF
--- a/LCLS-II/core/rtl/TimingCore.vhd
+++ b/LCLS-II/core/rtl/TimingCore.vhd
@@ -391,6 +391,7 @@ begin
       appTimingBus_i.valid     <= timingValid;
       appTimingBus_i.modesel   <= modeSelRx;
       appTimingBus_i.extension <= timingExtension;
+      modeSelApp               <= modeSelRx;
    end generate;
 
    U_SYNC_LinkV1 : entity surf.Synchronizer

--- a/LCLS-II/evr/rtl/EvrV2TrigReg.vhd
+++ b/LCLS-II/evr/rtl/EvrV2TrigReg.vhd
@@ -95,30 +95,10 @@ begin
             v.triggerConfig(i).loadTap := r.loadShift(i)(3);
             v.loadShift(i)             := r.loadShift(i)(2 downto 0) & '0';
 
-            -- Check for read transaction
-            if (axilEp.axiStatus.readEnable = '1') then
-
-               -- Check the Address
-               if (StdMatch(axilReadMaster.araddr(11 downto 0), toSlv(i*GRP_C + 12, STRIDE_C))) then
-                  v.axilReadSlave.rdata(31 downto 6) := (others => '0');
-                  v.axilReadSlave.rdata(5 downto 0)  := delay_rd(i);
-                  axiSlaveReadResponse(v.axilReadSlave);
-               end if;
-
-            end if;
-
-            -- Check for Write transaction
-            if (axilEp.axiStatus.writeEnable = '1') then
-
-               -- Check the Address
-               if (StdMatch(axilWriteMaster.awaddr(11 downto 0), toSlv(i*GRP_C + 12, STRIDE_C))) then
-                  v.triggerConfig(i).delayTap := axilWriteMaster.wdata(5 downto 0);
-                  axiSlaveWriteResponse(v.axilWriteSlave);
-                  v.loadShift(i)(0)           := '1';
-               end if;
-
-            end if;
-
+            axiSlaveRegister (axilEp, toSlv(i*GRP_C + 12, STRIDE_C), 0, v.triggerConfig(i).delayTap);
+            axiSlaveRegisterR(axilEp, toSlv(i*GRP_C + 12, STRIDE_C),16, delay_rd(i));
+            axiWrDetect      (axilEp, toSlv(i*GRP_C + 12, STRIDE_C), v.loadShift(i)(0));
+            
          end if;
 
       end loop;

--- a/yaml/EvrV2TriggerReg.yaml
+++ b/yaml/EvrV2TriggerReg.yaml
@@ -62,7 +62,7 @@ EvrV2TriggerReg: &EvrV2TriggerReg
       class: IntField
       name: ComplEn
       sizeBits: 1
-      lsBit: 5
+      lsBit: 4
       mode: RW
       description: Enable complementary trigger outputs
     #########################################################  
@@ -72,7 +72,7 @@ EvrV2TriggerReg: &EvrV2TriggerReg
       class: IntField
       name: ComplAnd
       sizeBits: 1
-      lsBit: 6
+      lsBit: 5
       mode: RW
       enums:
         - name: LogicOR
@@ -112,14 +112,4 @@ EvrV2TriggerReg: &EvrV2TriggerReg
       lsBit: 0
       mode: RW
       description: Delay tap in ticks/64 (Only valid register is USE_TAP_C=true)
-    #########################################################  
-    DelayTapReadback:
-      at:
-        offset: 0x0E
-      class: IntField
-      name: DelayTapReadback
-      sizeBits: 6
-      lsBit: 0
-      mode: RO
-      description: Delay tap readback in ticks/64 (Only valid register is USE_TAP_C=true)
     #########################################################  

--- a/yaml/EvrV2TriggerReg.yaml
+++ b/yaml/EvrV2TriggerReg.yaml
@@ -111,5 +111,15 @@ EvrV2TriggerReg: &EvrV2TriggerReg
       sizeBits: 6
       lsBit: 0
       mode: RW
-      description: Delay tap in ticks/64 (Only valid register is USE_TAP_C=true)
+      description: Delay tap in 82ps ticks (Only valid register is USE_TAP_C=true)
+    #########################################################  
+    DelayTapReadback:
+      at:
+        offset: 0x0E
+      class: IntField
+      name: DelayTap
+      sizeBits: 6
+      lsBit: 0
+      mode: RO
+      description: Delay tap readback in 82ps ticks (Only valid register is USE_TAP_C=true)
     #########################################################  


### PR DESCRIPTION
### Description
- Fix yaml for Complementary trigger bits
- Update trigger registers to current axi-lite macros
- Add delayTap readback register to yaml
- Add missing modeSelApp output to TimingCore

### Impact
- Only the EvrCardG2 project uses the complementary triggers and delayTap.  
- lcls-ued-llrf might use the complementary triggers soon.
