### PR TITLE
Bug fix for race between between TimingRx RxRst to GthRxAlignCheck DRP read TXN

### DIFF
--- a/LCLS-II/core/rtl/TimingRx.vhd
+++ b/LCLS-II/core/rtl/TimingRx.vhd
@@ -354,7 +354,7 @@ begin
          WIDTH_G        => 4)
       port map (
          statusIn(0)  => rxR.clkCnt(rxR.clkCnt'left),
-         statusIn(1)  => rxStatus.resetDone,
+         statusIn(1)  => rxStatus.locked,
          statusIn(2)  => rxR.decErr,
          statusIn(3)  => rxR.dspErr,
          statusOut    => stv,


### PR DESCRIPTION
### Description
- ResetDone can up faster at this module before the 8B10B bus if the 8B10B bus is registered 
  - Example: Mux-ing between two different GTs like in PCIe application
  - I have observed this in simulation as well. 