### PR TITLE
V3.6.3 bsarate

### DIFF
--- a/LCLS-II/core/rtl/BsaControlv2.vhd
+++ b/LCLS-II/core/rtl/BsaControlv2.vhd
@@ -213,7 +213,7 @@ begin
        end if;
 
        -- count off the tmo in 10 ms steps
-       if r.tmoactive = '1' and fixedRate(4)='1' then
+       if r.tmoactive = '1' and fixedRate(2)='1' then
          if r.tmocnt = tmocnt then
            --  assert done
            v.bsaDone   := '1';

--- a/LCLS-II/core/rtl/BsaControlv2.vhd
+++ b/LCLS-II/core/rtl/BsaControlv2.vhd
@@ -30,6 +30,7 @@ entity BsaControl is
       sysclk     : in  sl;
       sysrst     : in  sl;
       bsadef     : in  BsaDefType;
+      tmo        : in  sl := '0';
       tmocnt     : in  slv( 3 downto 0) := x"F";  -- 10 ms steps
       nToAvgOut  : out slv(15 downto 0);
       avgToWrOut : out slv(15 downto 0);
@@ -140,7 +141,7 @@ begin
      avgToWrOUt <= r.avgToWr;
    end generate GEN_SYNC;
 
-   comb: process (r, txrst, enable, bsadef, beamSeq, rateSel, fixedRate, tmocnt) is
+   comb: process (r, txrst, enable, bsadef, beamSeq, rateSel, tmo, tmocnt) is
      variable v : RegType;
      variable destSel : sl;
      variable avgDone : sl;
@@ -213,7 +214,7 @@ begin
        end if;
 
        -- count off the tmo in 10 ms steps
-       if r.tmoactive = '1' and fixedRate(2)='1' then
+       if r.tmoactive = '1' and tmo='1' then
          if r.tmocnt = tmocnt then
            --  assert done
            v.bsaDone   := '1';

--- a/LCLS-II/core/rtl/TPGMini.vhd
+++ b/LCLS-II/core/rtl/TPGMini.vhd
@@ -182,6 +182,7 @@ begin
         sysclk     => txClk,
         sysrst     => txRst,
         bsadef     => config.bsadefv(i),
+        tmo        => frame.fixedRates(2),
         nToAvgOut  => status.bsaStatus(i)(15 downto 0),
         avgToWrOut => status.bsaStatus(i)(31 downto 16),
         txclk      => txClk,


### PR DESCRIPTION
Make an explicit signal interface for the BSA timeout.  It's currently wrong in production, but no one really noticed.