### PR TITLE
Use Gtye4ChannelDummy in gtyUltrascale+ core wrapper

### DIFF
--- a/LCLS-II/gtyUltraScale+/rtl/TimingGtCoreWrapper.vhd
+++ b/LCLS-II/gtyUltraScale+/rtl/TimingGtCoreWrapper.vhd
@@ -354,7 +354,7 @@ begin
 
    GEN_DISABLE_GT : if (DISABLE_TIME_GT_G = true) generate
 
-      U_TERM : entity surf.Gthe3ChannelDummy
+      U_TERM : entity surf.Gtye4ChannelDummy
          generic map (
             TPD_G   => TPD_G,
             WIDTH_G => 1)


### PR DESCRIPTION
The `gtyUltrascle+/TimingGtCoreWrapper` module was using `Gthe3ChannelDummy` instead of `Gtye4ChannelDummy`.
But `Gthe3ChannelDummy` doesn't even get loaded by ruckus for ultrascale+ designs.
This is now fixed.
