### PR TITLE
Release Candidate v3.8.3

### DIFF
--- a/LCLS-II/gtx7/rtl/TimingGtCoreWrapper.vhd
+++ b/LCLS-II/gtx7/rtl/TimingGtCoreWrapper.vhd
@@ -277,7 +277,7 @@ begin
          RX_OS_CFG_G           => "0000010000000",
          RXCDR_CFG_G           => RXCDR_CFG_C,
          RXDFEXYDEN_G          => '1',
-         RX_EQUALIZER_G        => "DFE",
+         RX_EQUALIZER_G        => "LPM",
          RXSLIDE_MODE_G        => "PMA",
          FIXED_COMMA_EN_G      => "0011",
          FIXED_ALIGN_COMMA_0_G => "----------0101111100",  -- Normal Comma


### PR DESCRIPTION
### Description
- Updating the RX RX_EQUALIZER_G from `DFE` to `LPM` (only impacts GTX7 FPGAs)
- Related to https://github.com/slaclab/evr-card-g2/pull/11