### PR TITLE
Updating code comments for Ultrascale/Ultrascale+ GTs wrapper

### DIFF
--- a/LCLS-II/core/rtl/TimingGthWrapper.vhd
+++ b/LCLS-II/core/rtl/TimingGthWrapper.vhd
@@ -25,6 +25,7 @@ entity TimingGthWrapper is
       TPD_G : time := 1 ns);
 
    port (
+      -- StableClk (which is GT's drpClk) in the IP core configured for 156.25MHz/2 (78.125MHz)
       stableClk : in sl;
 
       gtRefClk : in  sl;

--- a/LCLS-II/gthUltraScale+/rtl/TimingGthCoreWrapper.vhd
+++ b/LCLS-II/gthUltraScale+/rtl/TimingGthCoreWrapper.vhd
@@ -44,7 +44,7 @@ entity TimingGthCoreWrapper is
       axilReadSlave   : out AxiLiteReadSlaveType;
       axilWriteMaster : in  AxiLiteWriteMasterType;
       axilWriteSlave  : out AxiLiteWriteSlaveType;
-
+      -- StableClk (which is GT's drpClk) in the IP core configured for 156.25MHz/2 (78.125MHz)
       stableClk    : in  sl;  -- Unused in GTHE3, but used in GTHE4/GTYE4
       stableRst    : in  sl;  -- Unused in GTHE3, but used in GTHE4/GTYE4
       -- GTH FPGA IO

--- a/LCLS-II/gthUltraScale/rtl/TimingGtCoreWrapper.vhd
+++ b/LCLS-II/gthUltraScale/rtl/TimingGtCoreWrapper.vhd
@@ -44,7 +44,7 @@ entity TimingGtCoreWrapper is
       axilReadSlave   : out AxiLiteReadSlaveType;
       axilWriteMaster : in  AxiLiteWriteMasterType;
       axilWriteSlave  : out AxiLiteWriteSlaveType;
-
+      -- StableClk (which is GT's drpClk) in the IP core configured for 156.25MHz/2 (78.125MHz)
       stableClk    : in  sl;  -- Unused in GTHE3, but used in GTHE4/GTYE4
       stableRst    : in  sl;  -- Unused in GTHE3, but used in GTHE4/GTYE4
       -- GTH FPGA IO

--- a/LCLS-II/gtyUltraScale+/rtl/TimingGtCoreWrapper.vhd
+++ b/LCLS-II/gtyUltraScale+/rtl/TimingGtCoreWrapper.vhd
@@ -44,7 +44,7 @@ entity TimingGtCoreWrapper is
       axilReadSlave   : out AxiLiteReadSlaveType;
       axilWriteMaster : in  AxiLiteWriteMasterType;
       axilWriteSlave  : out AxiLiteWriteSlaveType;
-
+      -- StableClk (which is GT's drpClk) in the IP core configured for 156.25MHz/2 (78.125MHz)
       stableClk    : in  sl;  -- Unused in GTHE3, but used in GTHE4/GTYE4
       stableRst    : in  sl;  -- Unused in GTHE3, but used in GTHE4/GTYE4
       -- GTY FPGA IO


### PR DESCRIPTION
### Description
- StableClk (which is GT's drpClk) in the IP core configured for 156.25MHz/2 (78.125MHz)