### PR TITLE
Add Ruckus Flag to Load XCI Instead of DCP

### DIFF
--- a/LCLS-II/gthUltraScale+/ruckus.tcl
+++ b/LCLS-II/gthUltraScale+/ruckus.tcl
@@ -4,11 +4,13 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 if { $::env(VIVADO_VERSION) >= 2022.2} {
    loadSource -lib lcls_timing_core -dir "$::DIR_PATH/rtl"
 
-   loadSource -lib lcls_timing_core   -path "$::DIR_PATH/coregen/TimingGth_extref.dcp"
-   #loadIpCore -path "$::DIR_PATH/coregen/TimingGth_extref.xci"
-
-   loadSource -lib lcls_timing_core   -path "$::DIR_PATH/coregen/TimingGth_fixedlat.dcp"
-   #loadIpCore -path "$::DIR_PATH/coregen/TimingGth_fixedlat.xci"
+   if { [info exists ::env(LCLS_TIMING_XCI)] != 0 && $::env(LCLS_TIMING_XCI) == 1 } {
+       loadIpCore -path "$::DIR_PATH/coregen/TimingGth_extref.xci"
+       loadIpCore -path "$::DIR_PATH/coregen/TimingGth_fixedlat.xci"
+   } else {
+       loadSource -lib lcls_timing_core   -path "$::DIR_PATH/coregen/TimingGth_extref.dcp"
+       loadSource -lib lcls_timing_core   -path "$::DIR_PATH/coregen/TimingGth_fixedlat.dcp"
+   }
 } else {
    puts "\n\nWARNING: $::DIR_PATH requires Vivado 2022.2 (or later)\n\n"
 }

--- a/LCLS-II/gthUltraScale/ruckus.tcl
+++ b/LCLS-II/gthUltraScale/ruckus.tcl
@@ -5,11 +5,13 @@ if { $::env(VIVADO_VERSION) >= 2016.4 } {
 
    loadSource -lib lcls_timing_core -dir "$::DIR_PATH/rtl"
 
-   loadSource -lib lcls_timing_core   -path "$::DIR_PATH/coregen/TimingGth_extref.dcp"
-   # loadIpCore -path "$::DIR_PATH/coregen/TimingGth_extref.xci"
-
-   loadSource -lib lcls_timing_core   -path "$::DIR_PATH/coregen/TimingGth_fixedlat.dcp"
-   # loadIpCore -path "$::DIR_PATH/coregen/TimingGth_fixedlat.xci"
+   if { [info exists ::env(LCLS_TIMING_XCI)] != 0 && $::env(LCLS_TIMING_XCI) == 1 } {
+       loadIpCore -path "$::DIR_PATH/coregen/TimingGth_extref.xci"
+       loadIpCore -path "$::DIR_PATH/coregen/TimingGth_fixedlat.xci"
+   } else {
+       loadSource -lib lcls_timing_core   -path "$::DIR_PATH/coregen/TimingGth_extref.dcp"
+       loadSource -lib lcls_timing_core   -path "$::DIR_PATH/coregen/TimingGth_fixedlat.dcp"
+   }
 
 } else {
    puts "\n\nWARNING: $::DIR_PATH requires Vivado 2016.4 (or later)\n\n"

--- a/LCLS-II/gtyUltraScale+/ruckus.tcl
+++ b/LCLS-II/gtyUltraScale+/ruckus.tcl
@@ -14,19 +14,25 @@ if { [info exists ::env(TIMING_246MHz)] != 1 || $::env(TIMING_246MHz) == 0 } {
 
 if { $::env(VIVADO_VERSION) >= 2021.1 && [info exists ::env(TIMING_246MHz)] != 1} {
 
-   loadSource -lib lcls_timing_core   -path "${path}/TimingGty_extref.dcp"
-   # loadIpCore -path "${path}/TimingGty_extref.xci"
+   if { [info exists ::env(LCLS_TIMING_XCI)] != 0 && $::env(LCLS_TIMING_XCI) == 1 } {
+       loadIpCore -path "${path}/TimingGty_extref.xci"
+       loadIpCore -path "${path}/TimingGty_fixedlat.xci"
+       puts "Loading XCI files for LCLS Timing"
+   } else {
+       loadSource -lib lcls_timing_core   -path "${path}/TimingGty_extref.dcp"
+       loadSource -lib lcls_timing_core   -path "${path}/TimingGty_fixedlat.dcp"       
+   }      
 
-   loadSource -lib lcls_timing_core   -path "${path}/TimingGty_fixedlat.dcp"
-   # loadIpCore -path "${path}/TimingGty_fixedlat.xci"
 
 } elseif { $::env(VIVADO_VERSION) >= 2020.2 && [info exists ::env(TIMING_246MHz)] == 1 } {
 
-   loadSource -lib lcls_timing_core   -path "${path}/TimingGty_extref.dcp"
-   # loadIpCore -path "${path}/TimingGty_extref.xci"
-
-   loadSource -lib lcls_timing_core   -path "${path}/TimingGty_fixedlat.dcp"
-   # loadIpCore -path "${path}/TimingGty_fixedlat.xci"
+    if { [info exists ::env(LCLS_TIMING_XCI)] != 0 && $::env(LCLS_TIMING_XCI) == 1 } {
+	loadIpCore -path "${path}/TimingGty_extref.xci"
+	loadIpCore -path "${path}/TimingGty_fixedlat.xci"       
+    } else {
+	loadSource -lib lcls_timing_core   -path "${path}/TimingGty_extref.dcp"
+	loadSource -lib lcls_timing_core   -path "${path}/TimingGty_fixedlat.dcp"       
+    }      
 
 } else {
    puts "\n\nWARNING: $::DIR_PATH requires Vivado 2021.1 (or later)\n\n"


### PR DESCRIPTION
The ruckus.tcl files that load IP cores now look for an `LCLS_TIMING_XCI` environment variable.
If it is set to 1, then the XCI file is loaded instead of the DCP.

This is useful in simulation. For example, add this line to the target makefile so that the XCI is loaded when building the project for VCS simulation.
```Makefile
vcs: export LCLS_TIMING_XCI=1
```