### PR TITLE
Release Candidate v3.10.0

### DIFF
--- a/LCLS-II/gthUltraScale+/rtl/TimingGthCoreWrapper.vhd
+++ b/LCLS-II/gthUltraScale+/rtl/TimingGthCoreWrapper.vhd
@@ -34,6 +34,7 @@ entity TimingGthCoreWrapper is
       SIMULATION_G      : boolean          := false;
       DISABLE_TIME_GT_G : boolean          := false;
       EXTREF_G          : boolean          := false;
+      AXI_CLK_FREQ_G    : real             := 156.25e6;
       AXIL_BASE_ADDR_G  : slv(31 downto 0);
       ADDR_BITS_G       : positive         := 22;
       GTH_DRP_OFFSET_G  : slv(31 downto 0) := x"00400000");

--- a/LCLS-II/gthUltraScale+/rtl/TimingGthCoreWrapper.vhd
+++ b/LCLS-II/gthUltraScale+/rtl/TimingGthCoreWrapper.vhd
@@ -31,6 +31,7 @@ use unisim.vcomponents.all;
 entity TimingGthCoreWrapper is
    generic (
       TPD_G             : time             := 1 ns;
+      SIMULATION_G      : boolean          := false;
       DISABLE_TIME_GT_G : boolean          := false;
       EXTREF_G          : boolean          := false;
       AXIL_BASE_ADDR_G  : slv(31 downto 0);
@@ -302,15 +303,18 @@ begin
          mAxiReadMasters     => axilReadMasters,
          mAxiReadSlaves      => axilReadSlaves);
 
-   U_AlignCheck : entity lcls_timing_core.GthRxAlignCheck
+   U_AlignCheck : entity surf.GtRxAlignCheck
       generic map (
-         TPD_G      => TPD_G,
-         GT_TYPE_G  => "GTHE3",
-         DRP_ADDR_G => AXI_CROSSBAR_MASTERS_CONFIG_C(1).baseAddr)
+         TPD_G          => TPD_G,
+         SIMULATION_G   => SIMULATION_G,
+         GT_TYPE_G      => "GTHE4",
+         AXI_CLK_FREQ_G => AXI_CLK_FREQ_G,
+         DRP_ADDR_G     => AXI_CROSSBAR_MASTERS_CONFIG_C(1).baseAddr)
       port map (
          -- Clock Monitoring
          txClk            => txoutclkb,
          rxClk            => rxoutclkb,
+         refClk           => axilClk,   -- Could probably also be stableClk
          -- GTH Status/Control Interface
          resetIn          => rxControl.reset,
          resetDone        => bypassdone,

--- a/LCLS-II/gthUltraScale/rtl/TimingGtCoreWrapper.vhd
+++ b/LCLS-II/gthUltraScale/rtl/TimingGtCoreWrapper.vhd
@@ -31,6 +31,7 @@ use unisim.vcomponents.all;
 entity TimingGtCoreWrapper is
    generic (
       TPD_G             : time    := 1 ns;
+      SIMULATION_G      : boolean := false;
       DISABLE_TIME_GT_G : boolean := false;
       EXTREF_G          : boolean := false;
       AXIL_BASE_ADDR_G  : slv(31 downto 0);
@@ -298,15 +299,18 @@ begin
          mAxiReadMasters     => axilReadMasters,
          mAxiReadSlaves      => axilReadSlaves);
 
-   U_AlignCheck : entity lcls_timing_core.GthRxAlignCheck
+   U_AlignCheck : entity surf.GtRxAlignCheck
       generic map (
-         TPD_G      => TPD_G,
-         GT_TYPE_G  => "GTHE3",
-         DRP_ADDR_G => AXI_CROSSBAR_MASTERS_CONFIG_C(1).baseAddr)
+         TPD_G          => TPD_G,
+         SIMULATION_G   => SIMULATION_G,
+         GT_TYPE_G      => "GTHE3",
+         AXI_CLK_FREQ_G => AXI_CLK_FREQ_G,
+         DRP_ADDR_G     => AXI_CROSSBAR_MASTERS_CONFIG_C(1).baseAddr)
       port map (
          -- Clock Monitoring
          txClk            => txoutclkb,
          rxClk            => rxoutclkb,
+         refClk           => axilClk,   -- Could probably also be stableClk
          -- GTH Status/Control Interface
          resetIn          => rxControl.reset,
          resetDone        => bypassdone,

--- a/LCLS-II/gthUltraScale/rtl/TimingGtCoreWrapper.vhd
+++ b/LCLS-II/gthUltraScale/rtl/TimingGtCoreWrapper.vhd
@@ -34,6 +34,7 @@ entity TimingGtCoreWrapper is
       SIMULATION_G      : boolean := false;
       DISABLE_TIME_GT_G : boolean := false;
       EXTREF_G          : boolean := false;
+      AXI_CLK_FREQ_G    : real    := 156.25e6;
       AXIL_BASE_ADDR_G  : slv(31 downto 0);
       ADDR_BITS_G       : positive := 22;
       GTH_DRP_OFFSET_G  : slv(31 downto 0) := x"00400000");

--- a/LCLS-II/gtyUltraScale+/rtl/TimingGtCoreWrapper.vhd
+++ b/LCLS-II/gtyUltraScale+/rtl/TimingGtCoreWrapper.vhd
@@ -383,7 +383,7 @@ begin
       port map (
          -- Clock Monitoring
          txClk            => txoutclkb,
-         rxClk            => rxUsrClk,
+         rxClk            => rxoutclkb,
          refClk           => axilClk,   -- Could probably also be stableClk
          -- GTH Status/Control Interface
          resetIn          => rxControl.reset,


### PR DESCRIPTION
### Description
- [migrating from lcls_timing_core.GthRxAlignCheck to surf.GtRxAlignCheck](https://github.com/slaclab/lcls-timing-core/commit/9122f5ba289285c4f3f9890745d136894df68cbd)
- [Remove NO_FIFO implementation from EvrV2Trigger; its always needed.](https://github.com/slaclab/lcls-timing-core/commit/0ecfc2f92aec08e4bfe5a2ab52447d815f46a826)