### PR TITLE
Repo hygiene: pin/upgrade Actions to SHAs

### DIFF
--- a/.github/workflows/timing_ci.yml
+++ b/.github/workflows/timing_ci.yml
@@ -24,11 +24,11 @@ jobs:
     steps:
 
       # This step checks out a copy of your repository.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: 3.12
 
@@ -54,7 +54,7 @@ jobs:
 
       - name: Deploy Documentation
         if: startsWith(github.ref, 'refs/tags/')
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           publish_dir: doxygen/html


### PR DESCRIPTION
## Repo hygiene

- Upgrade third-party GitHub Actions to latest release, pinned to commit SHA (tag in trailing comment)

First-party `slaclab/ruckus` reusable workflows remain on `@main`.

### Verification
- [x] CI passes with upgraded, SHA-pinned actions
- [x] `LICENSE.txt` present with `Copyright (c) 2026`
