### PR TITLE
updating GTX7 with latest Vivado 2024.1 RXCDR_CFG_C for LCLS-II timing

### DIFF
--- a/LCLS-II/gtx7/rtl/TimingGtCoreWrapper.vhd
+++ b/LCLS-II/gtx7/rtl/TimingGtCoreWrapper.vhd
@@ -106,6 +106,7 @@ architecture rtl of TimingGtCoreWrapper is
    signal txClk       : sl := '0';
    signal txRst       : sl := '0';
    signal txReset     : sl := '0';
+   signal cPllLock    : sl := '0';
 
    signal drpRdy  : sl               := '0';
    signal drpEn   : sl               := '0';
@@ -123,7 +124,7 @@ begin
    rxStatus.bufferByDone <= gtRxResetDone;
    rxStatus.bufferByErr  <= not(dataValid) and linkUp;
 
-   txStatus.locked       <= txResetDone;
+   txStatus.locked       <= cPllLock;
    txStatus.resetDone    <= txResetDone;
    txStatus.bufferByDone <= txResetDone;
    txStatus.bufferByErr  <= '0';
@@ -286,7 +287,7 @@ begin
       port map (
          stableClkIn      => iStableClk,
          cPllRefClkIn     => gtRefClk,
-         cPllLockOut      => open,
+         cPllLockOut      => cPllLock,
          qPllRefClkIn     => '0',
          qPllClkIn        => '0',
          qPllLockIn       => '1',

--- a/LCLS-II/gtx7/rtl/TimingGtCoreWrapper.vhd
+++ b/LCLS-II/gtx7/rtl/TimingGtCoreWrapper.vhd
@@ -80,9 +80,7 @@ architecture rtl of TimingGtCoreWrapper is
    constant TXOUT_DIV_C         : integer    := ite(GT_CONFIG_G, 1, 2);
    constant RX_CLK25_DIV_C      : integer    := ite(GT_CONFIG_G, 15, 10);
    constant TX_CLK25_DIV_C      : integer    := ite(GT_CONFIG_G, 15, 10);
---   constant RXCDR_CFG_C       : bit_vector := ite(GT_CONFIG_G, x"03000023ff20400020", x"03000023ff40200020");
-   --  compensate for sync clock jitter
-   constant RXCDR_CFG_C         : bit_vector := ite(GT_CONFIG_G, x"03800023ff10200020", x"03000023ff40200020");
+   constant RXCDR_CFG_C         : bit_vector := ite(GT_CONFIG_G, x"03000023ff10200020", x"03000023ff40200020");
    constant STABLE_CLK_PERIOD_C : real       := 4.0E-9;
 
    signal gtRefClk      : sl               := '0';

--- a/LCLS-II/gtx7/rtl/TimingGtCoreWrapper.vhd
+++ b/LCLS-II/gtx7/rtl/TimingGtCoreWrapper.vhd
@@ -29,10 +29,11 @@ use unisim.vcomponents.all;
 
 entity TimingGtCoreWrapper is
    generic (
-      TPD_G             : time       := 1 ns;
-      CPLL_REFCLK_SEL_G : bit_vector := "001";
-      REFCLK_G          : boolean    := false;  --  FALSE: use gtRefClkP/N,  TRUE: use gtRefClkIn
-      GT_CONFIG_G       : boolean    := true);  -- V1 = false, V2 = true
+      TPD_G                 : time       := 1 ns;
+      SIM_GTRESET_SPEEDUP_G : boolean    := false;
+      CPLL_REFCLK_SEL_G     : bit_vector := "001";
+      REFCLK_G              : boolean    := false;  --  FALSE: use gtRefClkP/N,  TRUE: use gtRefClkIn
+      GT_CONFIG_G           : boolean    := true);  -- V1 = false, V2 = true
    port (
       -- AXI-Lite Port
       axilClk         : in  sl;
@@ -175,7 +176,7 @@ begin
 
       iStableClk <= stableClk;
       iStableRst <= stableRst;
-      gtRefClk <= gtRefClkIn;
+      gtRefClk   <= gtRefClkIn;
 
    end generate;
 
@@ -241,7 +242,7 @@ begin
    U_Gtx : entity surf.Gtx7Core
       generic map (
          TPD_G                 => TPD_G,
-         SIM_GTRESET_SPEEDUP_G => "FALSE",
+         SIM_GTRESET_SPEEDUP_G => ite(SIM_GTRESET_SPEEDUP_G, "TRUE", "FALSE"),
          SIM_VERSION_G         => "4.0",
          SIMULATION_G          => false,
          STABLE_CLOCK_PERIOD_G => STABLE_CLK_PERIOD_C,


### PR DESCRIPTION
### Description
- [updating GTX7 with latest Vivado 2024.1 RXCDR_CFG_C for LCLS-II timing](https://github.com/slaclab/lcls-timing-core/commit/6d3b6d59659e165ad32663cefe7d15d6c6af9159)