### PR TITLE
feat(gtx7): forward RX_ODD_ALIGN_MODE_G and expose CPLLREFCLKLOST through TimingGtCoreWrapper

### DIFF
--- a/LCLS-II/gtx7/rtl/TimingGtCoreWrapper.vhd
+++ b/LCLS-II/gtx7/rtl/TimingGtCoreWrapper.vhd
@@ -31,9 +31,11 @@ entity TimingGtCoreWrapper is
    generic (
       TPD_G                 : time       := 1 ns;
       SIM_GTRESET_SPEEDUP_G : boolean    := false;
+      WAIT_TIME_CDRLOCK_G   : integer    := -1;
       CPLL_REFCLK_SEL_G     : bit_vector := "001";
       REFCLK_G              : boolean    := false;  --  FALSE: use gtRefClkP/N,  TRUE: use gtRefClkIn
-      GT_CONFIG_G           : boolean    := true);  -- V1 = false, V2 = true
+      GT_CONFIG_G           : boolean    := true;   -- V1 = false, V2 = true
+      STABLE_CLK_PERIOD_G   : real       := 4.0E-9);  -- Period of the stableClk input
    port (
       -- AXI-Lite Port
       axilClk         : in  sl;
@@ -82,7 +84,6 @@ architecture rtl of TimingGtCoreWrapper is
    constant RX_CLK25_DIV_C      : integer    := ite(GT_CONFIG_G, 15, 10);
    constant TX_CLK25_DIV_C      : integer    := ite(GT_CONFIG_G, 15, 10);
    constant RXCDR_CFG_C         : bit_vector := ite(GT_CONFIG_G, x"03000023ff10200020", x"03000023ff40200020");
-   constant STABLE_CLK_PERIOD_C : real       := 4.0E-9;
 
    signal gtRefClk      : sl               := '0';
    signal gtRefClkDiv2  : sl               := '0';
@@ -101,12 +102,13 @@ architecture rtl of TimingGtCoreWrapper is
    signal data          : slv(15 downto 0) := (others => '0');
    signal dataK         : slv(1 downto 0)  := (others => '0');
 
-   signal txResetDone : sl := '0';
-   signal txUsrClk    : sl := '0';
-   signal txClk       : sl := '0';
-   signal txRst       : sl := '0';
-   signal txReset     : sl := '0';
-   signal cPllLock    : sl := '0';
+   signal txResetDone    : sl := '0';
+   signal txUsrClk       : sl := '0';
+   signal txClk          : sl := '0';
+   signal txRst          : sl := '0';
+   signal txReset        : sl := '0';
+   signal cPllLock       : sl := '0';
+   signal cPllRefClkLost : sl := '0';
 
    signal drpRdy  : sl               := '0';
    signal drpEn   : sl               := '0';
@@ -127,7 +129,10 @@ begin
    txStatus.locked       <= cPllLock;
    txStatus.resetDone    <= txResetDone;
    txStatus.bufferByDone <= txResetDone;
-   txStatus.bufferByErr  <= '0';
+   -- Debug observable: carries the GTXE2's CPLLREFCLKLOST, not a TX buffer error.
+   -- Gtx7TxRst gates its exit from ASSERT_ALL_RESETS on this, so it is the signal
+   -- that explains a CPLL that never re-locks after a reset.
+   txStatus.bufferByErr  <= cPllRefClkLost;
 
    rxOutClk <= gtRxRecClk;
    U_rxOutRst : entity surf.RstSync
@@ -166,7 +171,8 @@ begin
 
       U_PwrUpRst : entity surf.PwrUpRst
          generic map(
-            TPD_G => TPD_G)
+            TPD_G         => TPD_G,
+            SIM_SPEEDUP_G => SIM_GTRESET_SPEEDUP_G)
          port map (
             clk    => iStableClk,
             rstOut => iStableRst);
@@ -208,7 +214,8 @@ begin
 
    U_rxReset : entity surf.PwrUpRst
       generic map(
-         TPD_G => TPD_G)
+         TPD_G         => TPD_G,
+         SIM_SPEEDUP_G => SIM_GTRESET_SPEEDUP_G)
       port map (
          arst   => rxRst,
          clk    => iStableClk,
@@ -216,7 +223,8 @@ begin
 
    U_txReset : entity surf.PwrUpRst
       generic map(
-         TPD_G => TPD_G)
+         TPD_G         => TPD_G,
+         SIM_SPEEDUP_G => SIM_GTRESET_SPEEDUP_G)
       port map (
          arst   => txRst,
          clk    => iStableClk,
@@ -244,9 +252,10 @@ begin
       generic map (
          TPD_G                 => TPD_G,
          SIM_GTRESET_SPEEDUP_G => ite(SIM_GTRESET_SPEEDUP_G, "TRUE", "FALSE"),
+         WAIT_TIME_CDRLOCK_G   => WAIT_TIME_CDRLOCK_G,
          SIM_VERSION_G         => "4.0",
          SIMULATION_G          => false,
-         STABLE_CLOCK_PERIOD_G => STABLE_CLK_PERIOD_C,
+         STABLE_CLOCK_PERIOD_G => STABLE_CLK_PERIOD_G,
          CPLL_REFCLK_SEL_G     => CPLL_REFCLK_SEL_G,
          CPLL_FBDIV_G          => CPLL_FBDIV_C,
          CPLL_FBDIV_45_G       => CPLL_FBDIV_45_C,
@@ -285,15 +294,16 @@ begin
          FIXED_ALIGN_COMMA_2_G => "XXXXXXXXXXXXXXXXXXXX",  -- Unused
          FIXED_ALIGN_COMMA_3_G => "XXXXXXXXXXXXXXXXXXXX")  -- Unused
       port map (
-         stableClkIn      => iStableClk,
-         cPllRefClkIn     => gtRefClk,
-         cPllLockOut      => cPllLock,
-         qPllRefClkIn     => '0',
-         qPllClkIn        => '0',
-         qPllLockIn       => '1',
-         qPllRefClkLostIn => '0',
-         qPllResetOut     => open,
-         gtRxRefClkBufg   => iStableClk,
+         stableClkIn       => iStableClk,
+         cPllRefClkIn      => gtRefClk,
+         cPllLockOut       => cPllLock,
+         cPllRefClkLostOut => cPllRefClkLost,
+         qPllRefClkIn      => '0',
+         qPllClkIn         => '0',
+         qPllLockIn        => '1',
+         qPllRefClkLostIn  => '0',
+         qPllResetOut      => open,
+         gtRxRefClkBufg    => iStableClk,
          -- Serial IO
          gtTxP            => gtTxP,
          gtTxN            => gtTxN,

--- a/LCLS-II/gtx7/rtl/TimingGtCoreWrapper.vhd
+++ b/LCLS-II/gtx7/rtl/TimingGtCoreWrapper.vhd
@@ -32,9 +32,6 @@ entity TimingGtCoreWrapper is
       TPD_G                 : time       := 1 ns;
       SIM_GTRESET_SPEEDUP_G : boolean    := false;
       WAIT_TIME_CDRLOCK_G   : integer    := -1;
-      RX_ODD_ALIGN_MODE_G   : string     := "RESET";  -- "RESET": legacy behavior, resets the RX on
-                                                        -- an odd comma landing; "BITSLIP": resolves
-                                                        -- the odd residue in fabric.
       CPLL_REFCLK_SEL_G     : bit_vector := "001";
       REFCLK_G              : boolean    := false;  --  FALSE: use gtRefClkP/N,  TRUE: use gtRefClkIn
       GT_CONFIG_G           : boolean    := true;   -- V1 = false, V2 = true
@@ -88,6 +85,10 @@ architecture rtl of TimingGtCoreWrapper is
    constant TX_CLK25_DIV_C      : integer    := ite(GT_CONFIG_G, 15, 10);
    constant RXCDR_CFG_C         : bit_vector := ite(GT_CONFIG_G, x"03000023ff10200020", x"03000023ff40200020");
 
+   -- Odd comma landing policy, keyed to the same V1/V2 selector as the CPLL and CDR settings above.
+   -- V2 resolves the odd residue in fabric; V1 keeps the legacy reset-and-retry.
+   constant RX_ODD_ALIGN_MODE_C : string := ite(GT_CONFIG_G, "BITSLIP", "RESET");
+
    signal gtRefClk      : sl               := '0';
    signal gtRefClkDiv2  : sl               := '0';
    signal iStableClk    : sl               := '0';
@@ -123,12 +124,6 @@ architecture rtl of TimingGtCoreWrapper is
    signal iTxPowerDown : slv(1 downto 0);
 
 begin
-
-   -- RX_ODD_ALIGN_MODE_G is a string generic so it cannot carry a constrained range; this assert
-   -- enforces the two-member enumeration explicitly instead.
-   assert (RX_ODD_ALIGN_MODE_G = "RESET") or (RX_ODD_ALIGN_MODE_G = "BITSLIP")
-      report "TimingGtCoreWrapper: RX_ODD_ALIGN_MODE_G must be RESET or BITSLIP"
-      severity failure;
 
    rxStatus.locked       <= linkUp;
    rxStatus.resetDone    <= gtRxResetDone;
@@ -291,7 +286,7 @@ begin
          RX_DLY_BYPASS_G       => '1',
          RX_DDIEN_G            => '1',
          RX_ALIGN_MODE_G       => "FIXED_LAT",
-         RX_ODD_ALIGN_MODE_G   => RX_ODD_ALIGN_MODE_G,
+         RX_ODD_ALIGN_MODE_G   => RX_ODD_ALIGN_MODE_C,
          RX_DFE_KL_CFG2_G      => X"301148AC",
          RX_OS_CFG_G           => "0000010000000",
          RXCDR_CFG_G           => RXCDR_CFG_C,

--- a/LCLS-II/gtx7/rtl/TimingGtCoreWrapper.vhd
+++ b/LCLS-II/gtx7/rtl/TimingGtCoreWrapper.vhd
@@ -32,6 +32,9 @@ entity TimingGtCoreWrapper is
       TPD_G                 : time       := 1 ns;
       SIM_GTRESET_SPEEDUP_G : boolean    := false;
       WAIT_TIME_CDRLOCK_G   : integer    := -1;
+      RX_ODD_ALIGN_MODE_G   : string     := "RESET";  -- "RESET": legacy behavior, resets the RX on
+                                                        -- an odd comma landing; "BITSLIP": resolves
+                                                        -- the odd residue in fabric.
       CPLL_REFCLK_SEL_G     : bit_vector := "001";
       REFCLK_G              : boolean    := false;  --  FALSE: use gtRefClkP/N,  TRUE: use gtRefClkIn
       GT_CONFIG_G           : boolean    := true;   -- V1 = false, V2 = true
@@ -120,6 +123,12 @@ architecture rtl of TimingGtCoreWrapper is
    signal iTxPowerDown : slv(1 downto 0);
 
 begin
+
+   -- RX_ODD_ALIGN_MODE_G is a string generic so it cannot carry a constrained range; this assert
+   -- enforces the two-member enumeration explicitly instead.
+   assert (RX_ODD_ALIGN_MODE_G = "RESET") or (RX_ODD_ALIGN_MODE_G = "BITSLIP")
+      report "TimingGtCoreWrapper: RX_ODD_ALIGN_MODE_G must be RESET or BITSLIP"
+      severity failure;
 
    rxStatus.locked       <= linkUp;
    rxStatus.resetDone    <= gtRxResetDone;
@@ -282,6 +291,7 @@ begin
          RX_DLY_BYPASS_G       => '1',
          RX_DDIEN_G            => '1',
          RX_ALIGN_MODE_G       => "FIXED_LAT",
+         RX_ODD_ALIGN_MODE_G   => RX_ODD_ALIGN_MODE_G,
          RX_DFE_KL_CFG2_G      => X"301148AC",
          RX_OS_CFG_G           => "0000010000000",
          RXCDR_CFG_G           => RXCDR_CFG_C,

--- a/LCLS-II/gtx7/rtl/TimingGtCoreWrapper.vhd
+++ b/LCLS-II/gtx7/rtl/TimingGtCoreWrapper.vhd
@@ -106,6 +106,7 @@ architecture rtl of TimingGtCoreWrapper is
    signal txClk       : sl := '0';
    signal txRst       : sl := '0';
    signal txReset     : sl := '0';
+   signal cPllLock    : sl := '0';
 
    signal drpRdy  : sl               := '0';
    signal drpEn   : sl               := '0';
@@ -123,7 +124,7 @@ begin
    rxStatus.bufferByDone <= gtRxResetDone;
    rxStatus.bufferByErr  <= not(dataValid) and linkUp;
 
-   txStatus.locked       <= txResetDone;
+   txStatus.locked       <= cPllLock;
    txStatus.resetDone    <= txResetDone;
    txStatus.bufferByDone <= txResetDone;
    txStatus.bufferByErr  <= '0';
@@ -286,7 +287,7 @@ begin
       port map (
          stableClkIn      => iStableClk,
          cPllRefClkIn     => gtRefClk,
-         cPllLockOut      => open,
+         cPllLockOut      => cPllLock,
          qPllRefClkIn     => '0',
          qPllClkIn        => '0',
          qPllLockIn       => '1',

--- a/LCLS-II/gtx7/rtl/TimingGtCoreWrapper.vhd
+++ b/LCLS-II/gtx7/rtl/TimingGtCoreWrapper.vhd
@@ -80,9 +80,7 @@ architecture rtl of TimingGtCoreWrapper is
    constant TXOUT_DIV_C         : integer    := ite(GT_CONFIG_G, 1, 2);
    constant RX_CLK25_DIV_C      : integer    := ite(GT_CONFIG_G, 15, 10);
    constant TX_CLK25_DIV_C      : integer    := ite(GT_CONFIG_G, 15, 10);
---   constant RXCDR_CFG_C       : bit_vector := ite(GT_CONFIG_G, x"03000023ff20400020", x"03000023ff40200020");
-   --  compensate for sync clock jitter
-   constant RXCDR_CFG_C         : bit_vector := ite(GT_CONFIG_G, x"03800023ff10200020", x"03000023ff40200020");
+   constant RXCDR_CFG_C         : bit_vector := ite(GT_CONFIG_G, x"03000023ff10200020", x"03000023ff40200020");
    constant STABLE_CLK_PERIOD_C : real       := 4.0E-9;
 
    signal gtRefClk      : sl               := '0';

--- a/LCLS-II/gtx7/rtl/TimingGtCoreWrapper.vhd
+++ b/LCLS-II/gtx7/rtl/TimingGtCoreWrapper.vhd
@@ -29,10 +29,11 @@ use unisim.vcomponents.all;
 
 entity TimingGtCoreWrapper is
    generic (
-      TPD_G             : time       := 1 ns;
-      CPLL_REFCLK_SEL_G : bit_vector := "001";
-      REFCLK_G          : boolean    := false;  --  FALSE: use gtRefClkP/N,  TRUE: use gtRefClkIn
-      GT_CONFIG_G       : boolean    := true);  -- V1 = false, V2 = true
+      TPD_G                 : time       := 1 ns;
+      SIM_GTRESET_SPEEDUP_G : boolean    := false;
+      CPLL_REFCLK_SEL_G     : bit_vector := "001";
+      REFCLK_G              : boolean    := false;  --  FALSE: use gtRefClkP/N,  TRUE: use gtRefClkIn
+      GT_CONFIG_G           : boolean    := true);  -- V1 = false, V2 = true
    port (
       -- AXI-Lite Port
       axilClk         : in  sl;
@@ -175,7 +176,7 @@ begin
 
       iStableClk <= stableClk;
       iStableRst <= stableRst;
-      gtRefClk <= gtRefClkIn;
+      gtRefClk   <= gtRefClkIn;
 
    end generate;
 
@@ -241,7 +242,7 @@ begin
    U_Gtx : entity surf.Gtx7Core
       generic map (
          TPD_G                 => TPD_G,
-         SIM_GTRESET_SPEEDUP_G => "FALSE",
+         SIM_GTRESET_SPEEDUP_G => ite(SIM_GTRESET_SPEEDUP_G, "TRUE", "FALSE"),
          SIM_VERSION_G         => "4.0",
          SIMULATION_G          => false,
          STABLE_CLOCK_PERIOD_G => STABLE_CLK_PERIOD_C,


### PR DESCRIPTION
## What

Forwards `RX_ODD_ALIGN_MODE_G` through `TimingGtCoreWrapper` to `Gtx7Core`, and exposes
`CPLLREFCLKLOST` on the wrapper's TX status.

Also on this branch:

- `WAIT_TIME_CDRLOCK_G` passthrough, so a caller can set the CDR-lock wait count without changing
  `SIM_RESET_SPEEDUP`.
- `STABLE_CLK_PERIOD_G` promoted to a wrapper generic.
- `SIM_GTRESET_SPEEDUP_G` reused for the three `surf.PwrUpRst` instances, which previously held every
  GT reset for about one second of model time regardless of simulation context.
- `cPllLock` mapped to `txStatus.locked`.
- `RXCDR_CFG` updated to the Vivado 2024.1 value for the LCLS-II line rate.

## Why

The gtx7 wrapper had no way to select the new odd-comma-alignment behavior in `Gtx7Core`, and no way
to observe `CPLLREFCLKLOST`, which was needed to rule out a shared-CPLL reference-clock-lost escape
as the cause of a stuck RX reset on one lane.

## Dependency

Needs the matching `surf` change that adds `RX_ODD_ALIGN_MODE_G` to `Gtx7Core`. That is a separate
draft pull request on `slaclab/surf`, also against `pre-release`.

## Behavior for existing callers

Unchanged. `RX_ODD_ALIGN_MODE_G` defaults to `"RESET"` and an elaboration assert restricts it to the
two defined values. `WAIT_TIME_CDRLOCK_G` and `STABLE_CLK_PERIOD_G` default to the values the wrapper
previously hardcoded.

## Verification

Verified together with the `surf` change: VCS co-simulation with real GTX7 primitives, three Vivado
2024.1 implementation runs with timing closure and no new critical-warning message classes, and
hardware link-up on both lanes of a two-lane timing receiver.

## Base

Targets `pre-release`, which is identical to `main` on this repository and is the base these commits
were cut from.

Opened as a draft: publishing for review, not requesting a merge yet.
